### PR TITLE
Improve layout on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width">
     <title>WebGPU Report</title>
 
     <meta name="description" content="Info on your browser's implementation of WebGPU" />


### PR DESCRIPTION
This PR removes `initial-scale=1.0` in meta viewport so that users on mobile have uncropped layout. 