### PR TITLE
Prevent overflow on tiny viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,6 +187,7 @@ look better, at copy/download time we make the text visible
     max-width: 100%;
     flex-wrap: wrap;
     justify-content: space-between;
+    overflow-wrap: anywhere;
   }
   td {
     flex: 1 1 auto;


### PR DESCRIPTION
Before vs After

<img width=50% src="https://github.com/webgpu/webgpureport.org/assets/634478/1f02d266-80d9-4c5a-9edc-b67c0a2e9f46"><img width=50% src="https://github.com/webgpu/webgpureport.org/assets/634478/45859b18-509a-4bdf-a34e-305ea40d3891">
