### PR TITLE
Handle cases where SharedWorker is not supported at all

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,7 @@ look better, at copy/download time we make the text visible
     pointer-events: none;
 }
 #forkongithub a {
+    margin-top: 8px;
     background: #000;
     color: #fff;
     text-decoration: none;

--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ function expandMapLike(obj, sort = true) {
 function setLikeToTableRows(values) {
   return values
     ? expandSetLike(values)
-    : [el('tr', {}, [el('td', {colSpan: 2, textContent: 'not yet implemented by this browser'})])];
+    : [el('tr', {}, [el('td', {colSpan: 2, className: 'nowrap', textContent: 'not yet implemented by this browser'})])];
 }
 
 function mapLikeToTableRows(values, sort = true) {
@@ -435,7 +435,15 @@ async function checkWorkers(workerType) {
     obj[feature] = supported ? success : [fail, {className: 'not-supported'}];
   };
 
-  const worker = new WorkerHelper('worker.js', workerType);
+  let worker;
+  try {
+    worker = new WorkerHelper('worker.js', workerType);
+  } catch(error) {
+    addElemToDocument(el('table', { className: 'worker' }, [
+      el('tbody', {}, setLikeToTableRows(undefined)),
+    ]));
+    return;
+  }
   const {rAF, gpu, adapter, device, context, offscreen: offscreenSupported, twoD } = await worker.getMessage('checkWebGPU', {canvas: offscreenCanvas}, [offscreenCanvas]);
   addSupportsRow('webgpu API', gpu, 'exists', 'n/a');
   if (gpu) {


### PR DESCRIPTION
Following https://github.com/webgpu/webgpureport.org/pull/12, I realized SharedWorker was not supported at all on Chrome for Android. This PR handles this case.

![image](https://github.com/webgpu/webgpureport.org/assets/634478/27abb33e-0fd1-48e0-aa77-5948858ef69c)
