### PR TITLE
Use synchronous GPUAdapter.info when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ async function adapterToElements(adapter) {
     return;
   }
   // UGH!
-  const adapterInfo = await (adapter.requestAdapterInfo ? adapter.requestAdapterInfo() : undefined);
+  const adapterInfo = adapter.info || await (adapter.requestAdapterInfo ? adapter.requestAdapterInfo() : undefined);
 
   const limitsSectionElem = el('tr', {className: 'section'}, [
     el('td', {colSpan: 2}, [createHeading('div', '-', 'limits:')]),


### PR DESCRIPTION
This PR uses `adapter.info` instead of `requestAdapterInfo()` when available.
This should be merged only when https://github.com/gpuweb/gpuweb/pull/4662 is added to the WebGPU spec.