### PR TITLE
Use featureLevel when requesting compatibility mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -699,7 +699,7 @@ async function main() {
     { powerPreference: "high-performance" },
     { powerPreference: "low-power", },
     { powerPreference: "low-power", forceFallbackAdapter: true, },
-    { compatibilityMode: true },
+    { compatibilityMode: true, featureLevel: "compatibility" },
   ];
 
   const adapterIds = new Map();


### PR DESCRIPTION
As we're enabling compatibility mode with the `featureLevel` request adapter option in https://issues.chromium.org/issues/366151404, this PR uses `featureLevel` when requesting compatibility mode while keeping `compatibilityMode`.

FYI @kainino0x