### PR TITLE
Use featureLevel GPUAdapter attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,8 +303,11 @@ function parseAdapterFlags(adapter) {
   const flags = {
     'isFallbackAdapter': adapter.isFallbackAdapter,
   };
+  if ('featureLevel' in adapter) {
+    flags.featureLevel = adapter.featureLevel;
+  }
   if ('isCompatibilityMode' in adapter) {
-    flags.isCompatibilityMode = adapter.isCompatibilityMode
+    flags.isCompatibilityMode = adapter.isCompatibilityMode;
   }
   return flags;
 }
@@ -593,7 +596,9 @@ async function checkWorker(parent, workerType) {
 function adapterOptionsToDesc(requestAdapterOptions, adapter) {
   const parts = [
     ...(adapter?.isFallbackAdapter ? ['fallback'] : []),
-    ...(adapter?.isCompatibilityMode ? ['compatibilityMode'] : []),
+    ...(adapter?.featureLevel == 'compatibility' || adapter?.isCompatibilityMode
+      ? ['compatibilityMode']
+      : []),
   ];
   return parts.length > 0
     ? parts.join(' ')


### PR DESCRIPTION
Following up on https://chromium-review.googlesource.com/c/chromium/src/+/6088045 and https://github.com/gpuweb/gpuweb/pull/5012, this PR uses the new `featureLevel` GPUAdapter attribute, when it's exposed.

cc @senorblanco @kainino0x

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/0069ac2e-10ba-47ea-8106-98f83b207e73" />
