### PR TITLE
Reformat adapter-info section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,12 @@ label {
 table.misc {
   min-width: 100%;
 }
+.sub-table {
+  padding: 0
+}
+.sub-table>table {
+  width: 100%;
+}
 .misc td:nth-child(2) {
   white-space: pre;
 }

--- a/index.js
+++ b/index.js
@@ -355,7 +355,15 @@ async function adapterToElements(adapter) {
       el('tr', {className: 'section'}, [
         el('td', {colSpan: 2}, [createHeading('div', '-', 'adapter info:')]),
       ]),
-      ...mapLikeToTableRows(parseAdapterInfo(adapter.info)),
+      el('tr', {}, [
+        el('td', {className: 'sub-table', colSpan: 2}, [
+          el('table', {className: 'sub-table'}, [
+            el('tbody', {}, [
+              ...mapLikeToTableRows(parseAdapterInfo(adapter.info)),
+            ]),
+          ]),
+        ]),
+      ]),
       el('tr', {className: 'section'}, [
         el('td', {colSpan: 2}, [createHeading('div', '-', 'flags:')]),
       ]),
@@ -708,7 +716,9 @@ function formatSectionForCopyPasteSave({head, rows}) {
     }
 
     if (lastNonEmptyColumn >= 0) {
-      row.cells[0].prepend(createHidden('* '));
+      if (!(row.cells[0].children[0] instanceof HTMLTableElement)) {
+        row.cells[0].prepend(createHidden('* '));
+      }
     }
   }
 }


### PR DESCRIPTION
The data was in 2 shared columns across all categories. That works for limits (name: limit). For features they use `colspan: 2`. For adapter info though the info is large where as the names are small so they arguably need different formatting.

Solved by nesting a table.

# Before:

<img width="1039" alt="Screenshot 2025-01-17 at 14 23 37" src="https://github.com/user-attachments/assets/8b426f85-cfc8-4114-b869-90e222ea7717" />

# After:

<img width="1041" alt="Screenshot 2025-01-17 at 14 23 45" src="https://github.com/user-attachments/assets/a9d3c149-1b1f-43db-9d29-06a20ae47c76" />
