### PR TITLE
Add `subgroupMatrixConfigs` adapter info support

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,20 +289,28 @@ function markDifferencesInLimits(adapter, device) {
 function parseAdapterInfo(adapterInfo) {
   return Object.fromEntries(
     mapLikeToKeyValueArray(adapterInfo).map(([k, v]) => {
-      if (k !== "memoryHeaps") {
-        return [k, v];
-      }
-      const value = adapterInfo.memoryHeaps.map(({ size, properties }) => {
-        const heapProperties = [];
-        for (const [k, v] of Object.entries(GPUHeapProperty)) {
-          if ((parseInt(properties, 10) & v) !== 0) {
-            heapProperties.push(k);
+      if (k === 'memoryHeaps') {
+        const value = adapterInfo.memoryHeaps.map(({ size, properties }) => {
+          const heapProperties = [];
+          for (const [k, v] of Object.entries(GPUHeapProperty)) {
+            if ((parseInt(properties, 10) & v) !== 0) {
+              heapProperties.push(k);
+            }
           }
-        }
-        return `[ size: ${size}, properties: ${heapProperties.join(" | ")} ]`;
-      });
-      return [k, [value.join(", ")]];
-    }),
+          return `[ size: ${size}, properties: ${heapProperties.join(' | ')} ]`;
+        });
+        return [k, [value.join(', ')]];
+      }
+      if (k === 'subgroupMatrixConfigs') {
+        const value = adapterInfo.subgroupMatrixConfigs.map(
+          ({ componentType, resultComponentType, K, M, N }) => {
+            return `[ componentType: '${componentType}', resultComponentType: '${resultComponentType}', M: ${M}, N: ${N}, K: ${K} ]`;
+          }
+        );
+        return [k, [value.join(', ')]];
+      }
+      return [k, v];
+    })
   );
 }
 


### PR DESCRIPTION
This PR adds `subgroupMatrixConfigs` adapter info support to https://webgpureport.org. 

You can try it with https://chromium-review.googlesource.com/c/chromium/src/+/6506429

<img width="720" alt="image" src="https://github.com/user-attachments/assets/f4db57ab-99ff-43b3-9df0-d81c3e6b133f" />

cc @jrprice