### PR TITLE
Add WebGPUCompatibilityMode origin trial token

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>WebGPU Report</title>
+    
+    <!-- WebGPUCompatibilityMode origin token expiring April 21, 2026 -->
+    <meta
+      http-equiv="origin-trial"
+      content="AsI7u9T2GoOpR+D/4OZsbAAUyhvvdsiXOHWEztSEBRYiLI7dYsBRYiScU+GsMaiD1yVjNNpstwfSU2jVj62gUg0AAABheyJvcmlnaW4iOiJodHRwczovL3dlYmdwdXJlcG9ydC5vcmc6NDQzIiwiZmVhdHVyZSI6IldlYkdQVUNvbXBhdGliaWxpdHlNb2RlIiwiZXhwaXJ5IjoxNzc2NzI5NjAwfQ=="
+    />
 
     <meta name="description" content="Info on your browser's implementation of WebGPU" />
     <meta name="keywords" content="webgpu gpu graphics" />


### PR DESCRIPTION
This PR adds token for the [WebGPU compatibility mode origin trial](https://developer.chrome.com/origintrials/#/view_trial/1489002626799370241) to https://webgpureport.org

FYI @senorblanco