### PR TITLE
move warnings to misc

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,8 @@ label {
 .logo {
   height: 1.5em;
 }
-table.misc {
+table.misc,
+table.warnings {
   min-width: 100%;
 }
 .sub-table {


### PR DESCRIPTION
follow-up to https://github.com/webgpu/webgpureport.org/pull/36

<img width="1078" height="729" alt="Screenshot 2025-07-28 at 19 58 02" src="https://github.com/user-attachments/assets/fd143f4b-ad5c-45a3-ae90-a1e5f04c98d6" />

note: I think it's important to call out this standard feature rather than make it just like the others in that section. This particular feature is supposed to be there and you aren't supposed to have to workaround the fact that it's missing.

On the other hand, I wonder if we should add others warnings like direct buffer and texture bindings that are eventually supposed to work everywhere be weren't in m0/m1